### PR TITLE
String equality check

### DIFF
--- a/src/main/java/com/mixpanel/mixpanelapi/ClientDelivery.java
+++ b/src/main/java/com/mixpanel/mixpanelapi/ClientDelivery.java
@@ -55,7 +55,7 @@ public class ClientDelivery {
                 if (messageContents == null) {
                     ret = false;
                 }
-                else if ((messageType != "event") && (messageType != "people")) {
+                else if (!messageType.equals("event") && !messageType.equals("people")) {
                     ret = false;
                 }
             }

--- a/src/test/java/com/mixpanel/mixpanelapi/MixpanelAPITest.java
+++ b/src/test/java/com/mixpanel/mixpanelapi/MixpanelAPITest.java
@@ -103,6 +103,18 @@ public class MixpanelAPITest
         assertTrue(c.isValidMessage(eventMessage));
     }
 
+    public void testValidate() {
+        ClientDelivery c = new ClientDelivery();
+        JSONObject event = mBuilder.event("a distinct id", "login", mSampleProps);
+        assertTrue(c.isValidMessage(event));
+        try {
+            JSONObject rebuitMessage = new JSONObject(event.toString());
+            assertTrue(c.isValidMessage(rebuitMessage));
+        } catch (JSONException e) {
+            fail("Failed to build JSONObject");
+        }
+    }
+
     public void testClientDelivery() {
         ClientDelivery c = new ClientDelivery();
         try {
@@ -118,6 +130,7 @@ public class MixpanelAPITest
 
             JSONObject set = mBuilder.set("a distinct id", mSampleProps);
             c.addMessage(set);
+
 
             Map<String, Long> increments = new HashMap<String, Long>();
             increments.put("a key", 24L);


### PR DESCRIPTION
The ClientDelivery.isValidMessage() uses == instead of equals(). This causes messages that are built using new JSONObject(json) to fail. 
