### PR TITLE
Fix for string equality check in isValidMessage

### DIFF
--- a/src/main/java/com/mixpanel/mixpanelapi/ClientDelivery.java
+++ b/src/main/java/com/mixpanel/mixpanelapi/ClientDelivery.java
@@ -27,10 +27,10 @@ public class ClientDelivery {
             String messageType = message.getString("message_type");
             JSONObject messageContent = message.getJSONObject("message");
 
-            if (messageType == "event") {
+            if (messageType.equals("event")) {
                 mEventsMessages.add(messageContent);
             }
-            else if (messageType == "people") {
+            else if (messageType.equals("people")) {
                 mPeopleMessages.add(messageContent);
             }
         } catch (JSONException e) {

--- a/src/test/java/com/mixpanel/mixpanelapi/MixpanelAPITest.java
+++ b/src/test/java/com/mixpanel/mixpanelapi/MixpanelAPITest.java
@@ -106,10 +106,13 @@ public class MixpanelAPITest
     public void testValidate() {
         ClientDelivery c = new ClientDelivery();
         JSONObject event = mBuilder.event("a distinct id", "login", mSampleProps);
-        assertTrue(c.isValidMessage(event));
+        assertTrue(c.isValidMessage(event));		
         try {
             JSONObject rebuitMessage = new JSONObject(event.toString());
             assertTrue(c.isValidMessage(rebuitMessage));
+			assertEquals(c.getEventsMessages().size(), 0);
+			c.addMessage(rebuitMessage);
+			assertEquals(c.getEventsMessages().size(), 1);
         } catch (JSONException e) {
             fail("Failed to build JSONObject");
         }


### PR DESCRIPTION
The ClientDelivery.isValidMessage uses == instead of equals(). This causes messages that are built using new JSONObject(json) to fail. 
