### PR TITLE
Import of data failed when sending special chars (umlaute)

### DIFF
--- a/src/main/java/com/mixpanel/mixpanelapi/Base64Coder.java
+++ b/src/main/java/com/mixpanel/mixpanelapi/Base64Coder.java
@@ -41,11 +41,11 @@ package com.mixpanel.mixpanelapi;
     * @return   A String with the Base64 encoded data.
     */
     public static String encodeString (String s) {
-	try {
-	    return new String(encode(s.getBytes("utf-8")));
-	} catch (UnsupportedEncodingException e) {
-	    throw new RuntimeException(e);
-	}
+        try {
+            return new String(encode(s.getBytes("utf-8")));
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**


### PR DESCRIPTION
When sending special chars (umlaute like öäü) during a data import the server returns 
com.mixpanel.mixpanelapi.MixpanelServerException: Server refused to accept messages, they may be malformed.

The problem is solved by using the method getBytes("utf-8") in the Base64Coder instead of getBytes().

getBytes()  encodes the json string with the default char set which is not necessarily utf-8.
see http://docs.oracle.com/javase/6/docs/api/java/lang/String.html#getBytes%28%29

TODO: check if there are side effects in other uses of the method encodeString
