### PR TITLE
Make stdPeopleMessage protected

### DIFF
--- a/src/main/java/com/mixpanel/mixpanelapi/MessageBuilder.java
+++ b/src/main/java/com/mixpanel/mixpanelapi/MessageBuilder.java
@@ -258,7 +258,7 @@ public class MessageBuilder {
         }
     }
 
-    private JSONObject stdPeopleMessage(String distinctId, String actionType, JSONObject properties, JSONObject modifiers) {
+    protected JSONObject stdPeopleMessage(String distinctId, String actionType, JSONObject properties, JSONObject modifiers) {
         // Nothing below should EVER throw a JSONException.
         try {
             JSONObject dataObj = new JSONObject();


### PR DESCRIPTION
There are a number of "people" operations that are not supported through
the Java API (such as `$unset`). Currently users are forced to
reimplement (read: copy/paste) the logic in stdPeopleMessage when they
should be able to add a simple one-line method that calls through to
stdPeopleMessage with a specific `actionType`.
