### PR TITLE
Check null on JSONObject.getNames

### DIFF
--- a/src/main/java/com/mixpanel/mixpanelapi/MessageBuilder.java
+++ b/src/main/java/com/mixpanel/mixpanelapi/MessageBuilder.java
@@ -372,8 +372,11 @@ public class MessageBuilder {
             dataObj.put("$distinct_id", distinctId);
             dataObj.put("$time", System.currentTimeMillis());
             if (null != modifiers) {
-                for(String key : JSONObject.getNames(modifiers)) {
-                    dataObj.put(key, modifiers.get(key));
+                final String[] keys = JSONObject.getNames(modifiers);
+                if (keys != null) {
+                  for(String key : keys) {
+                      dataObj.put(key, modifiers.get(key));
+                  }
                 }
             }
             JSONObject envelope = new JSONObject();


### PR DESCRIPTION
JSONObject.getNames has the awful property that if the argument is a
JSONObject with no keys, it returns `null` instead of an empty array.
When conditional logic is used to generate modifiers, it's easy to end
up getting one without any keys.
