### PR TITLE
Respect ip parameter in people calls

### DIFF
--- a/src/main/java/com/mixpanel/mixpanelapi/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/mixpanelapi/MixpanelAPI.java
@@ -93,7 +93,7 @@ public class MixpanelAPI {
         List<JSONObject> events = toSend.getEventsMessages();
         sendMessages(events, eventsUrl);
 
-        String peopleUrl = mPeopleEndpoint;
+        String peopleUrl = mPeopleEndpoint + "?" + ipParameter;
         List<JSONObject> people = toSend.getPeopleMessages();
         sendMessages(people, peopleUrl);
     }


### PR DESCRIPTION
We call the deliver method when sending people updates or event updates.  The ipParameter argument is used to set ip=1 or ip=0 for the requests generated by deliver.  In the absence of ipParameter for people updates, we default to appending geolocation information as if ip=1 had been passed.  We should update this method to make it possible to disable geolocation information for people updates.
