### PR TITLE
Decrease default socket read timeout

### DIFF
--- a/src/main/java/com/mixpanel/mixpanelapi/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/mixpanelapi/MixpanelAPI.java
@@ -199,7 +199,7 @@ public class MixpanelAPI {
     private final String mPeopleEndpoint;
 
     private static final int BUFFER_SIZE = 256; // Small, we expect small responses.
-    private static final int READ_TIMEOUT_MILLIS = 10000; // Ten seconds should be more than enough for a response.
-    private static final int CONNECT_TIMEOUT_MILLIS = 2000; // Two seconds should be more than enough for a response.
+    private static final int READ_TIMEOUT_MILLIS = 10000;
+    private static final int CONNECT_TIMEOUT_MILLIS = 2000;
 
 }

--- a/src/main/java/com/mixpanel/mixpanelapi/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/mixpanelapi/MixpanelAPI.java
@@ -200,6 +200,6 @@ public class MixpanelAPI {
 
     private static final int BUFFER_SIZE = 256; // Small, we expect small responses.
     private static final int READ_TIMEOUT_MILLIS = 10000; // Ten seconds should be more than enough for a response.
-    private static final int CONNECT_TIMEOUT_MILLIS = 30000; // 30 seconds should be more than enough for a response.
+    private static final int CONNECT_TIMEOUT_MILLIS = 2000; // Two seconds should be more than enough for a response.
 
 }

--- a/src/main/java/com/mixpanel/mixpanelapi/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/mixpanelapi/MixpanelAPI.java
@@ -199,7 +199,7 @@ public class MixpanelAPI {
     private final String mPeopleEndpoint;
 
     private static final int BUFFER_SIZE = 256; // Small, we expect small responses.
-    private static final int READ_TIMEOUT_MILLIS = 30000; // Thirty seconds should be more than enough for a response.
+    private static final int READ_TIMEOUT_MILLIS = 10000; // Ten seconds should be more than enough for a response.
     private static final int CONNECT_TIMEOUT_MILLIS = 30000; // 30 seconds should be more than enough for a response.
 
 }

--- a/src/main/java/com/mixpanel/mixpanelapi/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/mixpanelapi/MixpanelAPI.java
@@ -199,6 +199,6 @@ public class MixpanelAPI {
     private final String mPeopleEndpoint;
 
     private static final int BUFFER_SIZE = 256; // Small, we expect small responses.
-    private static final int READ_TIMEOUT_MILLIS = 120000; // Two minutes should be more than enough for a response.
+    private static final int READ_TIMEOUT_MILLIS = 30000; // Thirty seconds should be more than enough for a response.
 
 }


### PR DESCRIPTION
 * 2 minutes is a very long duration (computerwise). Especially if one
   has a rather high throughput of stuff being pushed to MixPanel.
 * 30 seconds is still a very long duration itself and I find it really
   hard to imagine that a submission really should take more than 10
   seconds. Also 30 seconds is generally the default socket read timeout
   I've seen in other open source projects (which are have generally
   higher latencies).

Question: What timeouts are your HTTP proxies/servers using?

Somewhat related to #21.