### PR TITLE
fix: Use TLS for all API calls

### DIFF
--- a/src/main/java/com/mixpanel/mixpanelapi/Config.java
+++ b/src/main/java/com/mixpanel/mixpanelapi/Config.java
@@ -1,6 +1,6 @@
 package com.mixpanel.mixpanelapi;
 
 /* package */ class Config {
-    public static final String BASE_ENDPOINT = "http://api.mixpanel.com";
+    public static final String BASE_ENDPOINT = "https://api.mixpanel.com";
     public static final int MAX_MESSAGE_SIZE = 50;
 }


### PR DESCRIPTION
Based [1] it looks like TLS can be used interchangably against unencrypted connections. I have sent a support e-mail to MixPanel to verify this, but I'm pretty sure this is the case.

This commit fixes #18.

[1] https://mixpanel.com/help/reference/http