### PR TITLE
added encodeDataString method to MixpanelAPI class

### DIFF
--- a/src/main/java/com/mixpanel/mixpanelapi/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/mixpanelapi/MixpanelAPI.java
@@ -30,8 +30,8 @@ public class MixpanelAPI {
     private static final int CONNECT_TIMEOUT_MILLIS = 2000;
     private static final int READ_TIMEOUT_MILLIS = 10000;
 
-    private final String mEventsEndpoint;
-    private final String mPeopleEndpoint;
+    protected final String mEventsEndpoint;
+    protected final String mPeopleEndpoint;
 
     /**
      * Constructs a MixpanelAPI object associated with the production, Mixpanel services.
@@ -108,6 +108,23 @@ public class MixpanelAPI {
     }
 
     /**
+     * apply Base64 encoding followed by URL encoding
+     *
+     * @param dataString JSON formatted string
+     * @return encoded string for <b>data</b> parameter in API call
+     * @throws NullPointerException If {@code dataString} is {@code null}
+     */
+    protected String encodeDataString(String dataString) {
+        try {
+            byte[] utf8data = dataString.getBytes("utf-8");
+            String base64data = new String(Base64Coder.encode(utf8data));
+            return URLEncoder.encode(base64data, "utf8");
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("Mixpanel library requires utf-8 support", e);
+        }
+    }
+
+    /**
      * Package scope for mocking purposes
      */
     /* package */ boolean sendData(String dataString, String endpointUrl) throws IOException {
@@ -118,15 +135,7 @@ public class MixpanelAPI {
         conn.setDoOutput(true);
         conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded;charset=utf8");
 
-        byte[] utf8data;
-        try {
-            utf8data = dataString.getBytes("utf-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException("Mixpanel library requires utf-8 support", e);
-        }
-
-        String base64data = new String(Base64Coder.encode(utf8data));
-        String encodedData = URLEncoder.encode(base64data, "utf8");
+        String encodedData = encodeDataString(dataString);
         String encodedQuery = "data=" + encodedData;
 
         OutputStream postStream = null;

--- a/src/test/java/com/mixpanel/mixpanelapi/MixpanelAPITest.java
+++ b/src/test/java/com/mixpanel/mixpanelapi/MixpanelAPITest.java
@@ -2,6 +2,7 @@ package com.mixpanel.mixpanelapi;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -471,6 +472,35 @@ public class MixpanelAPITest extends TestCase
         } catch (JSONException e) {
             fail("Can't interpret sends appropriately when sending large messages");
         }
+    }
+
+    public void testEncodeDataString(){
+        MixpanelAPI api = new MixpanelAPI("events url", "people url") {
+            @Override
+            public boolean sendData(String dataString, String endpointUrl) {
+                fail("Data sent when no data should be sent");
+                return true;
+            }
+        };
+
+        try{
+            api.encodeDataString(null);
+            fail("encodeDataString doesn't accept null string");
+        }catch(NullPointerException e){
+            // ok
+        }
+
+        // empty string
+        assertEquals("", api.encodeDataString(""));
+        // empty JSON
+        assertEquals("e30%3D", api.encodeDataString(new JSONObject().toString()));
+        // empty Array
+        assertEquals("W10%3D", api.encodeDataString(new JSONArray().toString()));
+        // JSON Object
+        assertEquals("eyJwcm9wIGtleSI6InByb3AgdmFsdWUiLCJyYXRpbyI6Is%2BAIn0%3D", api.encodeDataString(mSampleProps.toString()));
+        // JSON Array
+        JSONArray jsonArray = new JSONArray(Arrays.asList(mSampleProps));
+        assertEquals("W3sicHJvcCBrZXkiOiJwcm9wIHZhbHVlIiwicmF0aW8iOiLPgCJ9XQ%3D%3D", api.encodeDataString(jsonArray.toString()));
     }
 
     private void checkModifiers(JSONObject built) {


### PR DESCRIPTION
I'd like to build [Pixel based event tracking URL](https://mixpanel.com/docs/api-documentation/pixel-based-event-tracking) for my app but both tracking endpoint URL and encoding function in MixpanelAPI class aren't available from outside.

I don't want to implement same function in my app and in this PR, I did
- extract the encoding functionality from sendData method
- make the method and endpoint URL properties `protected`

This enables to create subclass like this

```java
public class MixpanelAPIExt extends MixpanelAPI{

    public String pixcelTrackingURL(JSONObject message, boolean useIpAddress) {
        String dataParam = encodeDataString(message.toString());
        StringBuilder buf = new StringBuilder();
        buf.append(this.mEventsEndpoint).append("/");
        buf.append("?data=").append(dataParam);
        buf.append("&ip=").append((useIpAddress) ? 1 : 0);
        buf.append("&img=1");
        return buf.toString();
    }
```

It's just small refactoring and I think this does not affect existing client applications of this library.