### PR TITLE
Add group profile update methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <distributionManagement>

--- a/src/main/java/com/mixpanel/mixpanelapi/ClientDelivery.java
+++ b/src/main/java/com/mixpanel/mixpanelapi/ClientDelivery.java
@@ -13,6 +13,7 @@ public class ClientDelivery {
 
     private final List<JSONObject> mEventsMessages = new ArrayList<JSONObject>();
     private final List<JSONObject> mPeopleMessages = new ArrayList<JSONObject>();
+    private final List<JSONObject> mGroupMessages = new ArrayList<JSONObject>();
 
     /**
      * Adds an individual message to this delivery. Messages to Mixpanel are often more efficient when sent in batches.
@@ -37,6 +38,9 @@ public class ClientDelivery {
             else if (messageType.equals("people")) {
                 mPeopleMessages.add(messageContent);
             }
+            else if (messageType.equals("group")) {
+                mGroupMessages.add(messageContent);
+            }
         } catch (JSONException e) {
             throw new RuntimeException("Apparently valid mixpanel message could not be interpreted.", e);
         }
@@ -59,7 +63,7 @@ public class ClientDelivery {
                 if (messageContents == null) {
                     ret = false;
                 }
-                else if (!messageType.equals("event") && !messageType.equals("people")) {
+                else if (!messageType.equals("event") && !messageType.equals("people") && !messageType.equals("group")) {
                     ret = false;
                 }
             }
@@ -76,6 +80,10 @@ public class ClientDelivery {
 
     /* package */ List<JSONObject> getPeopleMessages() {
         return mPeopleMessages;
+    }
+
+    /* package */ List<JSONObject> getGroupMessages() {
+        return mGroupMessages;
     }
 
 }

--- a/src/main/java/com/mixpanel/mixpanelapi/MessageBuilder.java
+++ b/src/main/java/com/mixpanel/mixpanelapi/MessageBuilder.java
@@ -296,6 +296,22 @@ public class MessageBuilder {
     }
 
     /**
+     * For each key and value in the properties argument, attempts to remove
+     * that value from a list associated with the key in the specified user profile.
+     */
+    public JSONObject remove(String distinctId, JSONObject properties) {
+        return remove(distinctId, properties, null);
+    }
+
+    /**
+     * For each key and value in the properties argument, attempts to remove
+     * that value from a list associated with the key in the specified user profile.
+     */
+    public JSONObject remove(String distinctId, JSONObject properties, JSONObject modifiers) {
+        return peopleMessage(distinctId, "$remove", properties, modifiers);
+    }
+
+    /**
      * Merges list-valued properties into a user profile.
      * The list values in the given are merged with the existing list on the user profile,
      * ignoring duplicate list values.
@@ -568,6 +584,21 @@ public class MessageBuilder {
         return groupMessage(groupKey, groupId, "$delete", new JSONObject(), modifiers);
     }
 
+    /**
+     * For each key and value in the properties argument, attempts to remove
+     * that value from a list associated with the key in the specified group profile.
+     */
+    public JSONObject groupRemove(String groupKey, String groupId, JSONObject properties) {
+        return groupRemove(groupKey, groupId, properties, null);
+    }
+
+    /**
+     * For each key and value in the properties argument, attempts to remove
+     * that value from a list associated with the key in the specified group profile.
+     */
+    public JSONObject groupRemove(String groupKey, String groupId, JSONObject properties, JSONObject modifiers) {
+        return groupMessage(groupKey, groupId, "$remove", properties, modifiers);
+    }
 
     /**
      * Merges list-valued properties into a group profile.

--- a/src/main/java/com/mixpanel/mixpanelapi/MessageBuilder.java
+++ b/src/main/java/com/mixpanel/mixpanelapi/MessageBuilder.java
@@ -136,6 +136,33 @@ public class MessageBuilder {
     }
 
     /**
+        * Sets a People Analytics property on the profile associated with
+        * the given distinctId, only if that property is not already set
+        * on the associated profile. So, to set a new property on
+        * on user 12345 if it is not already present, one might call:
+        * <pre>
+        * {@code
+        *     JSONObject userProperties = new JSONObject();
+        *     userProperties.put("Date Began", "2014-08-16");
+        *
+        *     // "Date Began" will not be overwritten, but if it isn't already
+        *     // present it will be set when we send this message.
+        *     JSONObject message = messageBuilder.setOnce("12345", userProperties);
+        *     mixpanelApi.sendMessage(message);
+        * }
+        * </pre>
+        *
+        * @param distinctId a string uniquely identifying the people analytics profile to change,
+        *           for example, a user id of an app, or the hostname of a server. If no profile
+        *           exists for the given id, a new one will be created.
+        * @param properties a collection of properties to set on the associated profile. Each key
+        *            in the properties argument will be updated on on the people profile
+        */
+    public JSONObject setOnce(String distinctId, JSONObject properties) {
+        return setOnce(distinctId, properties, null);
+    }
+
+    /**
      * Sets a People Analytics property on the profile associated with
      * the given distinctId, only if that property is not already set
      * on the associated profile. So, to set a new property on
@@ -273,9 +300,25 @@ public class MessageBuilder {
      * The list values in the given are merged with the existing list on the user profile,
      * ignoring duplicate list values.
      */
+    public JSONObject union(String distinctId, Map<String, JSONArray> properties) {
+        return union(distinctId, properties, null);
+    }
+
+    /**
+     * Merges list-valued properties into a user profile.
+     * The list values in the given are merged with the existing list on the user profile,
+     * ignoring duplicate list values.
+     */
     public JSONObject union(String distinctId, Map<String, JSONArray> properties, JSONObject modifiers) {
         JSONObject jsonProperties = new JSONObject(properties);
         return peopleMessage(distinctId, "$union", jsonProperties, modifiers);
+    }
+
+    /**
+     * Removes the properties named in propertyNames from the profile identified by distinctId.
+     */
+    public JSONObject unset(String distinctId, Collection<String> propertyNames) {
+        return unset(distinctId, propertyNames, null);
     }
 
     /**

--- a/src/main/java/com/mixpanel/mixpanelapi/MessageBuilder.java
+++ b/src/main/java/com/mixpanel/mixpanelapi/MessageBuilder.java
@@ -394,4 +394,236 @@ public class MessageBuilder {
         }
     }
 
+    /**
+     * Sets properties on the group profile identified by the given groupKey
+     * and groupId, creating the profile if needed. Existing values for the
+     * given properties are replaced. Example:
+     * <pre>
+     * {@code
+     *     JSONObject groupProperties = new JSONObject();
+     *     groupProperties.put("$name", "Acme Incorporated");
+     *     groupProperties.put("Industry", "Manufacturing");
+     *     JSONObject message = messageBuilder.groupSet("company", "Acme Inc.", groupProperties);
+     *     mixpanelApi.sendMessage(message);
+     * }
+     * </pre>
+     *
+     * @param groupKey the property that connects event data for Group Analytics
+     * @param groupId the identifier for a specific group
+     * @param properties a collection of properties to set on the associated profile. Each key
+     *            in the properties argument will be updated on on the people profile.
+     */
+    public JSONObject groupSet(String groupKey, String groupId, JSONObject properties) {
+        return groupSet(groupKey, groupId, properties, null);
+    }
+
+    /**
+     * Sets properties on the group profile identified by the given groupKey
+     * and groupId, creating the profile if needed. Existing values for the
+     * given properties are replaced. Example:
+     * <pre>
+     * {@code
+     *     JSONObject groupProperties = new JSONObject();
+     *     groupProperties.put("$name", "Acme Incorporated");
+     *     groupProperties.put("Industry", "Manufacturing");
+     *     JSONObject message = messageBuilder.groupSet("company", "Acme Inc.", groupProperties);
+     *     mixpanelApi.sendMessage(message);
+     * }
+     * </pre>
+     *
+     * @param groupKey the property that connects event data for Group Analytics
+     * @param groupId the identifier for a specific group
+     * @param properties a collection of properties to set on the associated profile. Each key
+     *            in the properties argument will be updated on on the people profile.
+     * @param modifiers Modifiers associated with the update message. (for example "$time" or "$ignore_time").
+     *            this can be null- if non-null, the keys and values in the modifiers
+     *            object will be associated directly with the update.
+     */
+    public JSONObject groupSet(String groupKey, String groupId, JSONObject properties, JSONObject modifiers) {
+        return groupMessage(groupKey, groupId, "$set", properties, modifiers);
+    }
+
+    /**
+     * Sets properties if they do not already exist on the group profile identified by the given groupKey
+     * and groupId. Example:
+     * <pre>
+     * {@code
+     *     JSONObject groupProperties = new JSONObject();
+     *     groupProperties.put("First Purchase", "Steel");
+     *     JSONObject message = messageBuilder.groupSetOnce("company", "Acme Inc.", groupProperties);
+     *     mixpanelApi.sendMessage(message);
+     * }
+     * </pre>
+     *
+     * @param groupKey the property that connects event data for Group Analytics
+     * @param groupId the identifier for a specific group
+     * @param properties a collection of properties to set on the associated profile. Each key
+     *            in the properties argument will be updated on on the people profile.
+     */
+    public JSONObject groupSetOnce(String groupKey, String groupId, JSONObject properties) {
+        return groupSetOnce(groupKey, groupId, properties, null);
+    }
+
+    /**
+     * Sets properties if they do not already exist on the group profile identified by the given groupKey
+     * and groupId. Example:
+     * <pre>
+     * {@code
+     *     JSONObject groupProperties = new JSONObject();
+     *     groupProperties.put("First Purchase", "Steel");
+     *     JSONObject message = messageBuilder.groupSetOnce("company", "Acme Inc.", groupProperties);
+     *     mixpanelApi.sendMessage(message);
+     * }
+     * </pre>
+     *
+     * @param groupKey the property that connects event data for Group Analytics
+     * @param groupId the identifier for a specific group
+     * @param properties a collection of properties to set on the associated profile. Each key
+     *            in the properties argument will be updated on on the people profile.
+     * @param modifiers Modifiers associated with the update message. (for example "$time" or "$ignore_time").
+     *            this can be null- if non-null, the keys and values in the modifiers
+     *            object will be associated directly with the update.
+     */
+    public JSONObject groupSetOnce(String groupKey, String groupId, JSONObject properties, JSONObject modifiers) {
+        return groupMessage(groupKey, groupId, "$set_once", properties, modifiers);
+    }
+
+    /**
+     * Deletes the group profile identified by the given groupKey and groupId.
+     *
+     * <pre>
+     * {@code
+     *     JSONObject message = messageBuilder.groupDelete("company", "Acme Inc.");
+     *     mixpanelApi.sendMessage(message);
+     * }
+     * </pre>
+     *
+     * @param groupKey the property that connects event data for Group Analytics
+     * @param groupId the identifier for a specific group
+     */
+    public JSONObject groupDelete(String groupKey, String groupId) {
+        return groupDelete(groupKey, groupId, null);
+    }
+
+    /**
+     * Deletes the group profile identified by the given groupKey and groupId.
+     *
+     * <pre>
+     * {@code
+     *     JSONObject message = messageBuilder.groupDelete("company", "Acme Inc.");
+     *     mixpanelApi.sendMessage(message);
+     * }
+     * </pre>
+     *
+     * @param groupKey the property that connects event data for Group Analytics
+     * @param groupId the identifier for a specific group
+     * @param modifiers Modifiers associated with the update message. (for example "$time" or "$ignore_time").
+     *            this can be null- if non-null, the keys and values in the modifiers
+     *            object will be associated directly with the update.
+     */
+    public JSONObject groupDelete(String groupKey, String groupId, JSONObject modifiers) {
+        return groupMessage(groupKey, groupId, "$delete", new JSONObject(), modifiers);
+    }
+
+
+    /**
+     * Merges list-valued properties into a group profile.
+     * The list values given are merged with the existing list on the group profile,
+     * ignoring duplicate list values.
+     */
+    public JSONObject groupUnion(String groupKey, String groupId, Map<String, JSONArray> properties) {
+        return groupUnion(groupKey, groupId, properties, null);
+    }
+
+    /**
+     * Merges list-valued properties into a group profile.
+     * The list values given are merged with the existing list on the group profile,
+     * ignoring duplicate list values.
+     */
+    public JSONObject groupUnion(String groupKey, String groupId, Map<String, JSONArray> properties,
+                              JSONObject modifiers) {
+        JSONObject jsonProperties = new JSONObject(properties);
+        return groupMessage(groupKey, groupId, "$union", jsonProperties, modifiers);
+    }
+
+    /**
+     * Removes the properties named in propertyNames from the group profile identified by groupKey and groupId.
+     */
+    public JSONObject groupUnset(String groupKey, String groupId, Collection<String> propertyNames) {
+        return groupUnset(groupKey, groupId, propertyNames, null);
+    }
+
+    /**
+     * Removes the properties named in propertyNames from the profile identified by distinctId.
+     */
+    public JSONObject groupUnset(String groupKey, String groupId, Collection<String> propertyNames,
+                                 JSONObject modifiers) {
+        JSONArray propNamesArray = new JSONArray(propertyNames);
+        return groupMessage(groupKey, groupId, "$unset", propNamesArray, modifiers);
+    }
+
+    /**
+     * Formats a generic group profile message.
+     * Use of this method requires familiarity with the underlying Mixpanel HTTP API,
+     * and it may be simpler and clearer to use the pre-built update methods. Use this
+     * method directly only when interacting with experimental APIs, or APIS that the
+     * rest of this library does not yet support.
+     *
+     * The underlying API is documented at https://mixpanel.com/help/reference/http
+     *
+     * @param groupKey string identifier for the type of group, e.g. 'Company'
+     * @param groupId unique string identifier for the group, e.g. 'Acme Inc.'
+     * @param actionType a string associated in the HTTP api with the operation (for example, $set or $add)
+     * @param properties a payload of the operation. Will be converted to JSON, and should be of types
+     *           Boolean, Double, Integer, Long, String, JSONArray, JSONObject, the JSONObject.NULL object, or null.
+     *           NaN and negative/positive infinity will throw an IllegalArgumentException
+     * @param modifiers if provided, the keys and values in the modifiers object will
+     *           be merged as modifiers associated with the update message (for example, "$time" or "$ignore_time")
+     *
+     * @throws IllegalArgumentException if properties is not intelligible as a JSONObject property
+     *
+     * @see MessageBuilder#groupSet(String groupKey, String groupId, JSONObject properties)
+     * @see MessageBuilder#groupSetOnce(String groupKey, String groupId, JSONObject properties)
+     * @see MessageBuilder#union(String groupKey, String groupId, JSONObject properties)
+     * @see MessageBuilder#remove(String groupKey, String groupId, JSONObject properties)
+     * @see MessageBuilder#unset(String groupKey, String groupId, JSONObject properties)
+     * @see MessageBuilder#groupDelete(String groupKey, String groupId)
+     */
+    public JSONObject groupMessage(String groupKey, String groupId, String actionType, Object properties,
+                                   JSONObject modifiers) {
+        JSONObject dataObj = new JSONObject();
+        if (null == properties) {
+            throw new IllegalArgumentException("Cannot send null properties, use JSONObject.NULL instead");
+        }
+
+        try {
+            dataObj.put(actionType, properties);
+        } catch (JSONException e) {
+            throw new IllegalArgumentException("Cannot interpret properties as a JSON payload", e);
+        }
+
+        // At this point, nothing should ever throw a JSONException
+        try {
+            dataObj.put("$token", mToken);
+            dataObj.put("$group_key", groupKey);
+            dataObj.put("$group_id", groupId);
+            dataObj.put("$time", System.currentTimeMillis());
+            if (null != modifiers) {
+                final String[] keys = JSONObject.getNames(modifiers);
+                if (keys != null) {
+                  for(String key : keys) {
+                      dataObj.put(key, modifiers.get(key));
+                  }
+                }
+            }
+            JSONObject envelope = new JSONObject();
+            envelope.put("envelope_version", 1);
+            envelope.put("message_type", "group");
+            envelope.put("message", dataObj);
+            return envelope;
+        } catch (JSONException e) {
+            throw new RuntimeException("Can't construct a Mixpanel message", e);
+        }
+    }
+
 }

--- a/src/main/java/com/mixpanel/mixpanelapi/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/mixpanelapi/MixpanelAPI.java
@@ -32,16 +32,17 @@ public class MixpanelAPI {
 
     protected final String mEventsEndpoint;
     protected final String mPeopleEndpoint;
+    protected final String mGroupsEndpoint;
 
     /**
      * Constructs a MixpanelAPI object associated with the production, Mixpanel services.
      */
     public MixpanelAPI() {
-        this(Config.BASE_ENDPOINT + "/track", Config.BASE_ENDPOINT + "/engage");
+        this(Config.BASE_ENDPOINT + "/track", Config.BASE_ENDPOINT + "/engage", Config.BASE_ENDPOINT + "/groups");
     }
 
     /**
-     * Create a MixpaneAPI associated with custom URLS for the Mixpanel service.
+     * Create a MixpaneAPI associated with custom URLS for events and people updates.
      *
      * Useful for testing and proxying. Most callers should use the constructor with no arguments.
      *
@@ -52,6 +53,23 @@ public class MixpanelAPI {
     public MixpanelAPI(String eventsEndpoint, String peopleEndpoint) {
         mEventsEndpoint = eventsEndpoint;
         mPeopleEndpoint = peopleEndpoint;
+        mGroupsEndpoint = Config.BASE_ENDPOINT + "/groups";
+    }
+
+    /**
+     * Create a MixpaneAPI associated with custom URLS for the Mixpanel service.
+     *
+     * Useful for testing and proxying. Most callers should use the constructor with no arguments.
+     *
+     * @param eventsEndpoint a URL that will accept Mixpanel events messages
+     * @param peopleEndpoint a URL that will accept Mixpanel people messages
+     * @param groupsEndpoint a URL that will accept Mixpanel groups messages
+     * @see #MixpanelAPI()
+     */
+    public MixpanelAPI(String eventsEndpoint, String peopleEndpoint, String groupsEndpoint) {
+        mEventsEndpoint = eventsEndpoint;
+        mPeopleEndpoint = peopleEndpoint;
+        mGroupsEndpoint = groupsEndpoint;
     }
 
     /**
@@ -105,6 +123,10 @@ public class MixpanelAPI {
         String peopleUrl = mPeopleEndpoint + "?" + ipParameter;
         List<JSONObject> people = toSend.getPeopleMessages();
         sendMessages(people, peopleUrl);
+
+        String groupsUrl = mGroupsEndpoint + "?" + ipParameter;
+        List<JSONObject> groupMessages = toSend.getGroupMessages();
+        sendMessages(groupMessages, groupsUrl);
     }
 
     /**

--- a/src/test/java/com/mixpanel/mixpanelapi/MixpanelAPITest.java
+++ b/src/test/java/com/mixpanel/mixpanelapi/MixpanelAPITest.java
@@ -173,6 +173,12 @@ public class MixpanelAPITest extends TestCase
         }
 
         {
+            JSONObject remove = mBuilder.remove("a distinct id", mSampleProps, mSampleModifiers);
+            checkModifiers(remove);
+            checkProfileProps("$remove", remove);
+        }
+
+        {
             JSONArray union1 = new JSONArray(new String[]{ "One", "Two" });
             JSONArray union2 = new JSONArray(new String[]{ "a", "b" });
 
@@ -299,6 +305,12 @@ public class MixpanelAPITest extends TestCase
                 JSONObject groupDelete = mBuilder.groupDelete("company", "Acme Inc.", mSampleModifiers);
                 checkModifiers(groupDelete, true);
                 assertTrue(groupDelete.getJSONObject("message").has("$delete"));
+            }
+
+            {
+                JSONObject groupRemove = mBuilder.groupRemove("company", "Acme Inc.", mSampleProps, mSampleModifiers);
+                checkModifiers(groupRemove, true);
+                checkProfileProps("$remove", groupRemove);
             }
 
             {

--- a/src/test/java/com/mixpanel/mixpanelapi/MixpanelAPITest.java
+++ b/src/test/java/com/mixpanel/mixpanelapi/MixpanelAPITest.java
@@ -28,8 +28,10 @@ public class MixpanelAPITest extends TestCase
     private JSONObject mSampleModifiers;
     private String mEventsMessages;
     private String mPeopleMessages;
+    private String mGroupMessages;
     private String mIpEventsMessages;
     private String mIpPeopleMessages;
+    private String mIpGroupMessages;
     private long mTimeZero;
 
     /**
@@ -67,7 +69,7 @@ public class MixpanelAPITest extends TestCase
 
         final Map<String, String> sawData = new HashMap<String, String>();
 
-        MixpanelAPI api = new MixpanelAPI("events url", "people url") {
+        MixpanelAPI api = new MixpanelAPI("events url", "people url", "groups url") {
             @Override
             public boolean sendData(String dataString, String endpointUrl) {
                 sawData.put(endpointUrl, dataString);
@@ -88,6 +90,9 @@ public class MixpanelAPITest extends TestCase
         JSONObject increment = mBuilder.increment("a distinct id", increments);
         c.addMessage(increment);
 
+        JSONObject groupSet = mBuilder.groupSet("company", "Acme Inc.", mSampleProps);
+        c.addMessage(groupSet);
+
         try {
             api.deliver(c, false);
         } catch (IOException e) {
@@ -96,6 +101,7 @@ public class MixpanelAPITest extends TestCase
 
         mEventsMessages = sawData.get("events url?ip=0");
         mPeopleMessages = sawData.get("people url?ip=0");
+        mGroupMessages = sawData.get("groups url?ip=0");
         sawData.clear();
 
         try {
@@ -106,6 +112,7 @@ public class MixpanelAPITest extends TestCase
 
         mIpEventsMessages = sawData.get("events url?ip=1");
         mIpPeopleMessages = sawData.get("people url?ip=1");
+        mIpGroupMessages = sawData.get("groups url?ip=1");
     }
 
     public void testEmptyJSON() {
@@ -118,13 +125,13 @@ public class MixpanelAPITest extends TestCase
         {
             JSONObject set = mBuilder.set("a distinct id", mSampleProps, mSampleModifiers);
             checkModifiers(set);
-            checkPeopleProps("$set", set);
+            checkProfileProps("$set", set);
         }
 
         {
             JSONObject setOnce = mBuilder.setOnce("a distinct id", mSampleProps, mSampleModifiers);
             checkModifiers(setOnce);
-            checkPeopleProps("$set_once", setOnce);
+            checkProfileProps("$set_once", setOnce);
         }
 
         {
@@ -147,7 +154,7 @@ public class MixpanelAPITest extends TestCase
         {
             JSONObject append = mBuilder.append("a distinct id", mSampleProps, mSampleModifiers);
             checkModifiers(append);
-            checkPeopleProps("$append", append);
+            checkProfileProps("$append", append);
         }
 
         {
@@ -230,6 +237,106 @@ public class MixpanelAPITest extends TestCase
         }
     }
 
+    public void testGroupProfileMessageBuilds()
+           throws JSONException {
+            {
+                JSONObject groupSet = mBuilder.groupSet("company", "Acme Inc.", mSampleProps, mSampleModifiers);
+                checkModifiers(groupSet, true);
+                checkProfileProps("$set", groupSet);
+            }
+
+            {
+                JSONObject groupSetOnce = mBuilder.groupSetOnce("company", "Acme Inc.", mSampleProps, mSampleModifiers);
+                checkModifiers(groupSetOnce, true);
+                checkProfileProps("$set_once", groupSetOnce);
+            }
+
+            {
+                JSONObject groupDelete = mBuilder.groupDelete("company", "Acme Inc.", mSampleModifiers);
+                checkModifiers(groupDelete, true);
+                assertTrue(groupDelete.getJSONObject("message").has("$delete"));
+            }
+
+            {
+                JSONArray union1 = new JSONArray(new String[]{ "One", "Two" });
+                JSONArray union2 = new JSONArray(new String[]{ "a", "b" });
+
+                Map<String, JSONArray> unions = new HashMap<String, JSONArray>();
+                unions.put("k1", union1);
+                unions.put("k2", union2);
+
+                JSONObject groupUnion = mBuilder.groupUnion("company", "Acme Inc.", unions, mSampleModifiers);
+                checkModifiers(groupUnion, true);
+                JSONObject payload = groupUnion.getJSONObject("message").getJSONObject("$union");
+                assertEquals(payload.getJSONArray("k1"), union1);
+                assertEquals(payload.getJSONArray("k2"), union2);
+            }
+
+            {
+                Set<String> toUnset = new HashSet<String>();
+                toUnset.add("One");
+                toUnset.add("Two");
+                JSONObject groupUnset = mBuilder.groupUnset("company", "Acme Inc.", toUnset, mSampleModifiers);
+                checkModifiers(groupUnset, true);
+                JSONArray payload = groupUnset.getJSONObject("message").getJSONArray("$unset");
+
+                for (int i = 0; i < payload.length(); i++) {
+                    String propName = payload.getString(i);
+                    assertTrue(toUnset.remove(propName));
+                }
+
+                assertTrue(toUnset.isEmpty());
+            }
+
+        }
+
+        public void testGroupMessageBadArguments() {
+            mBuilder.groupMessage("group_key", "group_id", "action", true, null);
+            mBuilder.groupMessage("group_key", "group_id", "action", 1.21, null);
+            mBuilder.groupMessage("group_key", "group_id", "action", 100, null);
+            mBuilder.groupMessage("group_key", "group_id", "action", 1000L, null);
+            mBuilder.groupMessage("group_key", "group_id", "action", "String", null);
+            mBuilder.groupMessage("group_key", "group_id", "action", JSONObject.NULL, null);
+
+            // Current, less than wonderful behavior- we'll just call toString()
+            // on random objects passed in.
+            mBuilder.groupMessage("group_key", "group_id", "action", new Object(), null);
+
+            JSONArray jsa = new JSONArray();
+            mBuilder.groupMessage("group_key", "group_id", "action", jsa, null);
+
+            JSONObject jso = new JSONObject();
+            mBuilder.groupMessage("group_key", "group_id", "action", jso, null);
+
+            try {
+                mBuilder.groupMessage("group_key", "group_id", "action", null, null);
+                fail("groupMessage did not throw an exception on null");
+            } catch (IllegalArgumentException e) {
+                // ok
+            }
+
+            try {
+                mBuilder.groupMessage("group_key", "group_id", "action", Double.NaN, null);
+                fail("groupMessage did not throw on NaN");
+            } catch (IllegalArgumentException e) {
+                // ok
+            }
+
+            try {
+                mBuilder.groupMessage("group_key", "group_id", "action", Double.NaN, null);
+                fail("groupMessage did not throw on NaN");
+            } catch (IllegalArgumentException e) {
+                // ok
+            }
+
+            try {
+                mBuilder.groupMessage("group_key", "group_id", "action", Double.NEGATIVE_INFINITY, null);
+                fail("groupMessage did not throw on infinity");
+            } catch (IllegalArgumentException e) {
+                // ok
+            }
+        }
+
     public void testMessageFormat() {
         ClientDelivery c = new ClientDelivery();
         assertFalse(c.isValidMessage(mSampleProps));
@@ -302,6 +409,9 @@ public class MixpanelAPITest extends TestCase
             JSONObject set = mBuilder.set("a distinct id", mSampleProps);
             c.addMessage(set);
 
+            JSONObject groupSet = mBuilder.groupSet("company", "Acme Inc.", mSampleProps);
+            c.addMessage(groupSet);
+
 
             Map<String, Long> increments = new HashMap<String, Long>();
             increments.put("a key", 24L);
@@ -315,6 +425,7 @@ public class MixpanelAPITest extends TestCase
     public void testApiSendIpArgs() {
         assertEquals(mEventsMessages, mIpEventsMessages);
         assertEquals(mPeopleMessages, mIpPeopleMessages);
+        assertEquals(mGroupMessages, mIpGroupMessages);
     }
 
     public void testApiSendEvent() {
@@ -504,17 +615,25 @@ public class MixpanelAPITest extends TestCase
     }
 
     private void checkModifiers(JSONObject built) {
+        checkModifiers(built, false);
+    }
+    private void checkModifiers(JSONObject built, boolean forGroups) {
         try {
             JSONObject msg = built.getJSONObject("message");
             assertEquals(msg.getString("$time"), "A TIME");
             assertEquals(msg.getString("Unexpected"), "But OK");
-            assertEquals(msg.getString("$distinct_id"), "a distinct id");
+            if (forGroups) {
+                assertEquals(msg.getString("$group_key"), "company");
+                assertEquals(msg.getString("$group_id"), "Acme Inc.");
+            } else {
+                assertEquals(msg.getString("$distinct_id"), "a distinct id");
+            }
         } catch (JSONException e) {
             fail(e.toString());
         }
     }
 
-    private void checkPeopleProps(String operation, JSONObject built) {
+    private void checkProfileProps(String operation, JSONObject built) {
         try {
             JSONObject msg = built.getJSONObject("message");
             JSONObject props = msg.getJSONObject(operation);


### PR DESCRIPTION
Adds group profile update methods using the /groups endpoint. See https://developer.mixpanel.com/docs/http#section-group-analytics

Also adds missing $remove method for both /groups and /engage, and makes the `modifiers` argument optional in all profile update methods (user + group) on MessageBuilder.