### PR TITLE
fix: Use JDK 11 for OpenFeature provider release

### DIFF
--- a/.github/workflows/release-openfeature.yml
+++ b/.github/workflows/release-openfeature.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up JDK 8
       uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
       with:
-        java-version: '8'
+        java-version: '11'
         distribution: 'temurin'
 
     - name: Cache Maven dependencies

--- a/openfeature-provider/pom.xml
+++ b/openfeature-provider/pom.xml
@@ -39,8 +39,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
## Summary
- OpenFeature SDK 1.20.1 requires Java 11 (class version 55.0)
- Updated release workflow from JDK 8 to JDK 11
- Updated `openfeature-provider/pom.xml` compiler source/target from 1.8 to 11
- Matches the CI configuration which already uses JDK 11+ for this module

🤖 Generated with [Claude Code](https://claude.com/claude-code)