### PR TITLE
fix(openfeature): handle JSONObject/JSONArray in objectToValue

### DIFF
--- a/openfeature-provider/src/main/java/com/mixpanel/openfeature/MixpanelProvider.java
+++ b/openfeature-provider/src/main/java/com/mixpanel/openfeature/MixpanelProvider.java
@@ -7,6 +7,8 @@ import com.mixpanel.mixpanelapi.featureflags.model.SelectedVariant;
 import com.mixpanel.mixpanelapi.featureflags.provider.BaseFlagsProvider;
 import com.mixpanel.mixpanelapi.featureflags.provider.LocalFlagsProvider;
 import dev.openfeature.sdk.*;
+import org.json.JSONArray;
+import org.json.JSONObject;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -263,6 +265,9 @@ public class MixpanelProvider implements FeatureProvider {
         if (obj == null) {
             return new Value();
         }
+        if (obj == JSONObject.NULL) {
+            return new Value();
+        }
         if (obj instanceof Boolean) {
             return new Value((Boolean) obj);
         }
@@ -307,6 +312,22 @@ public class MixpanelProvider implements FeatureProvider {
             ArrayList<Value> values = new ArrayList<>();
             for (Object item : arr) {
                 values.add(objectToValue(item));
+            }
+            return new Value(values);
+        }
+        if (obj instanceof JSONObject) {
+            JSONObject json = (JSONObject) obj;
+            Map<String, Value> structure = new HashMap<>();
+            for (String key : json.keySet()) {
+                structure.put(key, objectToValue(json.get(key)));
+            }
+            return new Value(new ImmutableStructure(structure));
+        }
+        if (obj instanceof JSONArray) {
+            JSONArray arr = (JSONArray) obj;
+            ArrayList<Value> values = new ArrayList<>();
+            for (int i = 0; i < arr.length(); i++) {
+                values.add(objectToValue(arr.get(i)));
             }
             return new Value(values);
         }


### PR DESCRIPTION
Response by The Claudefather:

## Summary
- The core flags SDK's `RemoteFlagsProvider` stores object variant values as `org.json.JSONObject` inside `SelectedVariant`. That shape is public API and we don't want to change it (existing users may depend on it).
- The OpenFeature provider's `objectToValue` translator had branches for `Map`, `List`, `Object[]`, primitives, and `String` — but no `JSONObject`/`JSONArray` branches. JSON objects fell through to `new Value(obj.toString())`, producing a String Value instead of a `Structure` Value.
- Result: `client.getObjectDetails(...)` on an object flag returned a plain-string Value; `value.asStructure()` was null, breaking spec-compliant OpenFeature usage.

## Fix
Add `JSONObject` / `JSONArray` / `JSONObject.NULL` handling in `MixpanelProvider.objectToValue`. Purely additive — no core SDK changes, no signature changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)