### PR TITLE
chore(openfeature): bump version to 0.1.1

### DIFF
--- a/openfeature-provider/pom.xml
+++ b/openfeature-provider/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.mixpanel</groupId>
     <artifactId>mixpanel-java-openfeature</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
     <packaging>jar</packaging>
     <name>Mixpanel Java SDK - OpenFeature Provider</name>
     <description>


### PR DESCRIPTION
## Summary
- Bumps `openfeature-provider/pom.xml` module version from `0.1.0` → `0.1.1` so the source on `master` matches the next artifact we publish to Maven Central. `0.1.0` is already live on Central.
- Prep for running the **Release OpenFeature Provider to Maven Central** workflow with input `0.1.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)