### PR TITLE
fix(analytics): allow capability to offload reportExposure to async thread

### DIFF
--- a/src/main/java/com/mixpanel/mixpanelapi/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/mixpanelapi/MixpanelAPI.java
@@ -10,6 +10,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLEncoder;
 import java.util.List;
+import java.util.concurrent.Executor;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.zip.GZIPOutputStream;
@@ -663,16 +664,42 @@ public class MixpanelAPI implements AutoCloseable {
     /**
      * Creates an EventSender that uses the provided MixpanelAPI instance for sending events.
      * This is shared by both local and remote flag evaluation modes.
+     * <p>
+     * If the config provides a non-null exposure executor, the HTTP send is dispatched on
+     * the executor so flag evaluation does not block on network I/O. JSON construction
+     * always runs on the calling thread because {@link MessageBuilder} is not thread-safe.
+     * </p>
      */
     private static EventSender createEventSender(BaseFlagsConfig config, MixpanelAPI api) {
         final MessageBuilder builder = new MessageBuilder(config.getProjectToken());
+        final Executor exposureExecutor = config.getExposureExecutor();
 
         return (distinctId, eventName, properties) -> {
+            final JSONObject event;
             try {
-                JSONObject event = builder.event(distinctId, eventName, properties);
-                api.sendMessage(event);
-            } catch (IOException e) {
-                // Silently fail - exposure tracking should not break flag evaluation
+                event = builder.event(distinctId, eventName, properties);
+            } catch (RuntimeException e) {
+                logger.log(Level.WARNING, "Failed to build exposure event " + eventName, e);
+                return;
+            }
+
+            Runnable send = () -> {
+                try {
+                    api.sendMessage(event);
+                } catch (IOException e) {
+                    logger.log(Level.WARNING, "Failed to send exposure event " + eventName, e);
+                }
+            };
+
+            if (exposureExecutor == null) {
+                send.run();
+                return;
+            }
+
+            try {
+                exposureExecutor.execute(send);
+            } catch (Exception e) {
+                logger.log(Level.WARNING, "Exposure event dropped — executor failed to accept task for " + eventName, e);
             }
         };
     }

--- a/src/main/java/com/mixpanel/mixpanelapi/featureflags/config/BaseFlagsConfig.java
+++ b/src/main/java/com/mixpanel/mixpanelapi/featureflags/config/BaseFlagsConfig.java
@@ -1,5 +1,7 @@
 package com.mixpanel.mixpanelapi.featureflags.config;
 
+import java.util.concurrent.Executor;
+
 /**
  * Base configuration for feature flags providers.
  * <p>
@@ -10,6 +12,7 @@ public class BaseFlagsConfig {
     private final String projectToken;
     private final String apiHost;
     private final int requestTimeoutSeconds;
+    private final Executor exposureExecutor;
 
     /**
      * Creates a new BaseFlagsConfig with specified settings.
@@ -17,11 +20,13 @@ public class BaseFlagsConfig {
      * @param projectToken the Mixpanel project token
      * @param apiHost the API endpoint host
      * @param requestTimeoutSeconds HTTP request timeout in seconds
+     * @param exposureExecutor executor used to dispatch exposure event HTTP sends; may be null
      */
-    protected BaseFlagsConfig(String projectToken, String apiHost, int requestTimeoutSeconds) {
+    protected BaseFlagsConfig(String projectToken, String apiHost, int requestTimeoutSeconds, Executor exposureExecutor) {
         this.projectToken = projectToken;
         this.apiHost = apiHost;
         this.requestTimeoutSeconds = requestTimeoutSeconds;
+        this.exposureExecutor = exposureExecutor;
     }
 
     /**
@@ -46,6 +51,13 @@ public class BaseFlagsConfig {
     }
 
     /**
+     * @return the Executor used to dispatch exposure event HTTP sends, or null for synchronous dispatch
+     */
+    public Executor getExposureExecutor() {
+        return exposureExecutor;
+    }
+
+    /**
      * Builder for BaseFlagsConfig.
      *
      * @param <T> the type of builder (for subclass builders)
@@ -55,6 +67,7 @@ public class BaseFlagsConfig {
         protected String projectToken;
         protected String apiHost = "api.mixpanel.com";
         protected int requestTimeoutSeconds = 10;
+        protected Executor exposureExecutor;
 
         /**
          * Sets the project token.
@@ -90,12 +103,33 @@ public class BaseFlagsConfig {
         }
 
         /**
+         * Sets the executor used to dispatch exposure event HTTP sends.
+         * <p>
+         * When null (the default), exposure events are sent synchronously on the
+         * calling thread — this adds HTTP latency to every flag evaluation when {@code reportExposure} is
+         * enabled.
+         * </p>
+         * <p>
+         * When set, the executor receives one {@link Runnable} per exposure event;
+         * each {@code Runnable} performs a single HTTP POST. If the
+         * executor fails to accept the task, the exposure event is dropped and a warning is logged.
+         * </p>
+         *
+         * @param exposureExecutor executor for exposure event dispatch, or null for synchronous
+         * @return this builder
+         */
+        public T exposureExecutor(Executor exposureExecutor) {
+            this.exposureExecutor = exposureExecutor;
+            return (T) this;
+        }
+
+        /**
          * Builds the BaseFlagsConfig instance.
          *
          * @return a new BaseFlagsConfig
          */
         public BaseFlagsConfig build() {
-            return new BaseFlagsConfig(projectToken, apiHost, requestTimeoutSeconds);
+            return new BaseFlagsConfig(projectToken, apiHost, requestTimeoutSeconds, exposureExecutor);
         }
     }
 

--- a/src/main/java/com/mixpanel/mixpanelapi/featureflags/config/LocalFlagsConfig.java
+++ b/src/main/java/com/mixpanel/mixpanelapi/featureflags/config/LocalFlagsConfig.java
@@ -1,5 +1,7 @@
 package com.mixpanel.mixpanelapi.featureflags.config;
 
+import java.util.concurrent.Executor;
+
 /**
  * Configuration for local feature flags evaluation.
  * <p>
@@ -17,11 +19,12 @@ public final class LocalFlagsConfig extends BaseFlagsConfig {
      * @param projectToken the Mixpanel project token
      * @param apiHost the API endpoint host
      * @param requestTimeoutSeconds HTTP request timeout in seconds
+     * @param exposureExecutor executor used to dispatch exposure event HTTP sends; may be null
      * @param enablePolling whether to periodically refresh flag definitions
      * @param pollingIntervalSeconds time between refresh cycles in seconds
      */
-    private LocalFlagsConfig(String projectToken, String apiHost, int requestTimeoutSeconds, boolean enablePolling, int pollingIntervalSeconds) {
-        super(projectToken, apiHost, requestTimeoutSeconds);
+    private LocalFlagsConfig(String projectToken, String apiHost, int requestTimeoutSeconds, Executor exposureExecutor, boolean enablePolling, int pollingIntervalSeconds) {
+        super(projectToken, apiHost, requestTimeoutSeconds, exposureExecutor);
         this.enablePolling = enablePolling;
         this.pollingIntervalSeconds = pollingIntervalSeconds;
     }
@@ -76,7 +79,7 @@ public final class LocalFlagsConfig extends BaseFlagsConfig {
          */
         @Override
         public LocalFlagsConfig build() {
-            return new LocalFlagsConfig(projectToken, apiHost, requestTimeoutSeconds, enablePolling, pollingIntervalSeconds);
+            return new LocalFlagsConfig(projectToken, apiHost, requestTimeoutSeconds, exposureExecutor, enablePolling, pollingIntervalSeconds);
         }
     }
 

--- a/src/main/java/com/mixpanel/mixpanelapi/featureflags/config/RemoteFlagsConfig.java
+++ b/src/main/java/com/mixpanel/mixpanelapi/featureflags/config/RemoteFlagsConfig.java
@@ -1,5 +1,7 @@
 package com.mixpanel.mixpanelapi.featureflags.config;
 
+import java.util.concurrent.Executor;
+
 /**
  * Configuration for remote feature flags evaluation.
  * <p>
@@ -15,9 +17,10 @@ public final class RemoteFlagsConfig extends BaseFlagsConfig {
      * @param projectToken the Mixpanel project token
      * @param apiHost the API endpoint host
      * @param requestTimeoutSeconds HTTP request timeout in seconds
+     * @param exposureExecutor executor used to dispatch exposure event HTTP sends; may be null
      */
-    private RemoteFlagsConfig(String projectToken, String apiHost, int requestTimeoutSeconds) {
-        super(projectToken, apiHost, requestTimeoutSeconds);
+    private RemoteFlagsConfig(String projectToken, String apiHost, int requestTimeoutSeconds, Executor exposureExecutor) {
+        super(projectToken, apiHost, requestTimeoutSeconds, exposureExecutor);
     }
 
     /**
@@ -32,7 +35,7 @@ public final class RemoteFlagsConfig extends BaseFlagsConfig {
          */
         @Override
         public RemoteFlagsConfig build() {
-            return new RemoteFlagsConfig(projectToken, apiHost, requestTimeoutSeconds);
+            return new RemoteFlagsConfig(projectToken, apiHost, requestTimeoutSeconds, exposureExecutor);
         }
     }
 


### PR DESCRIPTION
Allow passing an executor to report exposure for a feature flag getVariant call.

This Java SDK doesn't really have an established threading pattern, leaving it up to the caller to handle the threading model. 

This change attempts to still leave the caller in control of the threading model. Its not optimal that the default behavior at the moment is still that local getVariant calls will still be slow if reportExposure is enabled, because the http result must complete before the method returns. This behavior should still be further discussed.