### PR TITLE
fix(analytics): surface dropped exposure when distinct_id missing from context (SDK-84)

### DIFF
--- a/src/main/java/com/mixpanel/mixpanelapi/featureflags/provider/LocalFlagsProvider.java
+++ b/src/main/java/com/mixpanel/mixpanelapi/featureflags/provider/LocalFlagsProvider.java
@@ -671,7 +671,8 @@ public class LocalFlagsProvider extends BaseFlagsProvider<LocalFlagsConfig> impl
             // Surface the drop instead of silently returning so callers can
             // see they need to include distinct_id in the context.
             logger.log(Level.WARNING,
-                "Cannot track exposure event for flag '" + flagKey + "' without a distinct_id in the context");
+                "Cannot track exposure event for flag ''{0}'' without a distinct_id in the context",
+                flagKey);
             return;
         }
 

--- a/src/main/java/com/mixpanel/mixpanelapi/featureflags/provider/LocalFlagsProvider.java
+++ b/src/main/java/com/mixpanel/mixpanelapi/featureflags/provider/LocalFlagsProvider.java
@@ -665,6 +665,13 @@ public class LocalFlagsProvider extends BaseFlagsProvider<LocalFlagsConfig> impl
 
         Object distinctIdObj = context.get("distinct_id");
         if (distinctIdObj == null) {
+            // Local eval succeeds when the flag's Variant Assignment Key is
+            // something other than distinct_id (e.g., device_id), but the
+            // exposure event still needs distinct_id to attribute the user.
+            // Surface the drop instead of silently returning so callers can
+            // see they need to include distinct_id in the context.
+            logger.log(Level.WARNING,
+                "Cannot track exposure event for flag '" + flagKey + "' without a distinct_id in the context");
             return;
         }
 

--- a/src/test/java/com/mixpanel/mixpanelapi/featureflags/provider/LocalFlagsProviderTest.java
+++ b/src/test/java/com/mixpanel/mixpanelapi/featureflags/provider/LocalFlagsProviderTest.java
@@ -911,6 +911,7 @@ public class LocalFlagsProviderTest extends BaseFlagsProviderTest {
             public void close() {}
         };
         handler.setLevel(java.util.logging.Level.ALL);
+        java.util.logging.Level originalLevel = logger.getLevel();
         logger.addHandler(handler);
         logger.setLevel(java.util.logging.Level.ALL);
 
@@ -924,13 +925,18 @@ public class LocalFlagsProviderTest extends BaseFlagsProviderTest {
             assertEquals("value-a", result);
             // ...but exposure is dropped because distinct_id is missing.
             assertEquals(0, eventSender.getEvents().size());
-            // And we now log a warning so the drop isn't silent.
+            // And we now log a warning so the drop isn't silent. Use a
+            // formatter so we can match against the fully-resolved
+            // template (the raw LogRecord.getMessage() still contains {0}).
+            java.util.logging.SimpleFormatter formatter = new java.util.logging.SimpleFormatter();
             boolean warned = records.stream()
                 .filter(r -> r.getLevel().intValue() >= java.util.logging.Level.WARNING.intValue())
-                .anyMatch(r -> r.getMessage().contains("device-flag") && r.getMessage().contains("distinct_id"));
+                .map(formatter::formatMessage)
+                .anyMatch(m -> m.contains("device-flag") && m.contains("distinct_id"));
             assertTrue("expected a warning about the dropped exposure event", warned);
         } finally {
             logger.removeHandler(handler);
+            logger.setLevel(originalLevel);
         }
     }
 

--- a/src/test/java/com/mixpanel/mixpanelapi/featureflags/provider/LocalFlagsProviderTest.java
+++ b/src/test/java/com/mixpanel/mixpanelapi/featureflags/provider/LocalFlagsProviderTest.java
@@ -888,6 +888,52 @@ public class LocalFlagsProviderTest extends BaseFlagsProviderTest {
         assertEquals(0, eventSender.getEvents().size());
     }
 
+    // SDK-84: when the flag is bucketed on a non-distinct_id key (e.g.,
+    // device_id) and the context has that key but not distinct_id, local
+    // eval succeeds — but exposure still needs distinct_id to attribute the
+    // user. Surface the drop via a warning log instead of silently returning.
+    @Test
+    public void testWarnsWhenExposureDroppedDueToMissingDistinctId() throws Exception {
+        List<Variant> variants = Arrays.asList(new Variant("variant-a", "value-a", false, 1.0f));
+        List<Rollout> rollouts = Arrays.asList(new Rollout(1.0f));
+        // Flag is bucketed on device_id, not distinct_id.
+        String response = buildFlagsResponse("device-flag", "device_id", variants, rollouts, null);
+
+        provider = createProviderWithResponse(response);
+        provider.startPollingForDefinitions();
+
+        // Capture log records emitted from LocalFlagsProvider.
+        java.util.logging.Logger logger = java.util.logging.Logger.getLogger(LocalFlagsProvider.class.getName());
+        java.util.List<java.util.logging.LogRecord> records = new java.util.ArrayList<>();
+        java.util.logging.Handler handler = new java.util.logging.Handler() {
+            public void publish(java.util.logging.LogRecord record) { records.add(record); }
+            public void flush() {}
+            public void close() {}
+        };
+        handler.setLevel(java.util.logging.Level.ALL);
+        logger.addHandler(handler);
+        logger.setLevel(java.util.logging.Level.ALL);
+
+        try {
+            Map<String, Object> context = new HashMap<>();
+            context.put("device_id", "device-abc");
+
+            Object result = provider.getVariantValue("device-flag", fallbackVariantValue, context);
+
+            // Eval still succeeds — caller gets the real variant value.
+            assertEquals("value-a", result);
+            // ...but exposure is dropped because distinct_id is missing.
+            assertEquals(0, eventSender.getEvents().size());
+            // And we now log a warning so the drop isn't silent.
+            boolean warned = records.stream()
+                .filter(r -> r.getLevel().intValue() >= java.util.logging.Level.WARNING.intValue())
+                .anyMatch(r -> r.getMessage().contains("device-flag") && r.getMessage().contains("distinct_id"));
+            assertTrue("expected a warning about the dropped exposure event", warned);
+        } finally {
+            logger.removeHandler(handler);
+        }
+    }
+
     // #endregion
     // #region Readiness Tests
 


### PR DESCRIPTION
## Summary

When a flag uses a non-default Variant Assignment Key (e.g. `device_id`) and the evaluation context doesn't include `distinct_id`, local eval succeeds — flag definitions are cached, bucketing only needs the configured key — but `trackLocalExposure` then silently `return`s because it can only attribute the exposure event to a `distinct_id`. Caller gets the right flag value with no signal that analytics were dropped.

Add a `Level.WARNING` log so the drop becomes visible.

## Context

Linear: [SDK-84](https://linear.app/mixpanel/issue/SDK-84/silent-exposure-drop-when-bucketing-key-isnt-distinct-id). Only `Java` and `Ruby` are actually affected of the five SDKs the audit listed — Python / Go / Node already log when this happens.

This bug only affects **local evaluation**. Remote eval requires `distinct_id` at the eval step itself, so it errors out before reaching exposure tracking.

Behavior when `distinct_id` IS present (alongside the bucketing key) is unchanged — exposure still fires correctly attributed to the user.

## Test plan

- [x] All 54 `LocalFlagsProviderTest` tests pass (`mvn test`)
- [x] New `testWarnsWhenExposureDroppedDueToMissingDistinctId` exercises a `device_id`-bucketed flag with a context that has `device_id` but no `distinct_id`: asserts the variant value is returned, no exposure event is sent, AND a `WARNING` log is emitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
