### PR TITLE
fix(analytics): keep polling alive when fetch throws a Throwable (SDK-86)

### DIFF
--- a/src/main/java/com/mixpanel/mixpanelapi/featureflags/provider/LocalFlagsProvider.java
+++ b/src/main/java/com/mixpanel/mixpanelapi/featureflags/provider/LocalFlagsProvider.java
@@ -81,19 +81,8 @@ public class LocalFlagsProvider extends BaseFlagsProvider<LocalFlagsConfig> impl
                 return t;
             });
 
-            // Wrap in a Throwable-catching runnable: scheduleAtFixedRate
-            // permanently cancels future executions if a tick throws, and
-            // fetchDefinitions only catches Exception — so an Error
-            // (OOM, StackOverflowError, LinkageError, etc.) would silently
-            // kill polling for the lifetime of the JVM.
             pollingExecutor.scheduleAtFixedRate(
-                () -> {
-                    try {
-                        fetchDefinitions();
-                    } catch (Throwable t) {
-                        logger.log(Level.SEVERE, "Uncaught throwable in flag-definitions poll; continuing", t);
-                    }
-                },
+                this::fetchDefinitions,
                 config.getPollingIntervalSeconds(),
                 config.getPollingIntervalSeconds(),
                 TimeUnit.SECONDS
@@ -145,7 +134,7 @@ public class LocalFlagsProvider extends BaseFlagsProvider<LocalFlagsConfig> impl
             ready.set(true);
 
             logger.log(Level.FINE, "Successfully fetched " + newDefinitions.size() + " flag definitions");
-        } catch (Exception e) {
+        } catch (Throwable e) {
             logger.log(Level.WARNING, "Failed to fetch flag definitions", e);
         }
     }

--- a/src/main/java/com/mixpanel/mixpanelapi/featureflags/provider/LocalFlagsProvider.java
+++ b/src/main/java/com/mixpanel/mixpanelapi/featureflags/provider/LocalFlagsProvider.java
@@ -81,8 +81,19 @@ public class LocalFlagsProvider extends BaseFlagsProvider<LocalFlagsConfig> impl
                 return t;
             });
 
+            // Wrap in a Throwable-catching runnable: scheduleAtFixedRate
+            // permanently cancels future executions if a tick throws, and
+            // fetchDefinitions only catches Exception — so an Error
+            // (OOM, StackOverflowError, LinkageError, etc.) would silently
+            // kill polling for the lifetime of the JVM.
             pollingExecutor.scheduleAtFixedRate(
-                this::fetchDefinitions,
+                () -> {
+                    try {
+                        fetchDefinitions();
+                    } catch (Throwable t) {
+                        logger.log(Level.SEVERE, "Uncaught throwable in flag-definitions poll; continuing", t);
+                    }
+                },
                 config.getPollingIntervalSeconds(),
                 config.getPollingIntervalSeconds(),
                 TimeUnit.SECONDS

--- a/src/test/java/com/mixpanel/mixpanelapi/featureflags/provider/LocalFlagsProviderTest.java
+++ b/src/test/java/com/mixpanel/mixpanelapi/featureflags/provider/LocalFlagsProviderTest.java
@@ -11,6 +11,8 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.mixpanel.mixpanelapi.featureflags.provider.TestUtils.*;
 import static org.junit.Assert.*;
@@ -996,6 +998,55 @@ public class LocalFlagsProviderTest extends BaseFlagsProviderTest {
         assertEquals("new-value", result2);
 
         provider.stopPollingForDefinitions();
+    }
+
+    @Test
+    public void testPollingSurvivesThrowableFromFetch() throws Exception {
+        config = LocalFlagsConfig.builder()
+            .projectToken(TEST_TOKEN)
+            .enablePolling(true)
+            .pollingIntervalSeconds(1)
+            .build();
+
+        AtomicInteger callCount = new AtomicInteger(0);
+        AtomicReference<Throwable> nextThrow = new AtomicReference<>();
+        String validResponse = buildFlagsResponse(
+            flagKey, distinctIdContextKey,
+            Arrays.asList(new Variant("variant", "value", false, 1.0f)),
+            Arrays.asList(new Rollout(1.0f)),
+            null
+        );
+
+        LocalFlagsProvider throwingProvider = new LocalFlagsProvider(config, SDK_VERSION, eventSender) {
+            @Override
+            protected String httpGet(String urlString) {
+                callCount.incrementAndGet();
+                Throwable t = nextThrow.getAndSet(null);
+                if (t instanceof Error) throw (Error) t;
+                if (t instanceof RuntimeException) throw (RuntimeException) t;
+                return validResponse;
+            }
+        };
+
+        try {
+            // Initial fetch succeeds (call 1).
+            throwingProvider.startPollingForDefinitions();
+            assertEquals(1, callCount.get());
+
+            // Arm an Error to escape the next fetch.
+            nextThrow.set(new Error("simulated JVM-level failure"));
+            // 1s polling interval → wait long enough for two more ticks.
+            Thread.sleep(2500);
+
+            // Before the fix, scheduleAtFixedRate would have permanently
+            // cancelled the task on the Error and callCount would stop at 2.
+            assertTrue(
+                "Polling should continue after a Throwable: callCount=" + callCount.get(),
+                callCount.get() >= 3
+            );
+        } finally {
+            throwingProvider.stopPollingForDefinitions();
+        }
     }
 
     // #endregion


### PR DESCRIPTION
## Summary

`ScheduledExecutorService#scheduleAtFixedRate` permanently cancels future executions if the runnable throws an uncaught `Throwable`. `fetchDefinitions()` only catches `Exception`, so an `Error` (`OutOfMemoryError`, `StackOverflowError`, `LinkageError`, etc.) escaping would silently kill flag-definitions polling for the JVM's lifetime — and the thread factory has no `UncaughtExceptionHandler` to even surface it.

Wrap the scheduled runnable in a defensive `try { fetchDefinitions(); } catch (Throwable t) { logger.log(SEVERE, ...) }`. `fetchDefinitions()` keeps its `Exception` handling unchanged; the wrapper exists purely to swallow + log JVM-level escapes so the schedule keeps firing.

## Context

Linear: [SDK-86](https://linear.app/mixpanel/issue/SDK-86). Practical scope is narrow (JVM-level errors only) but the defense is one-line.

## Test plan

- [x] Full test suite passes (173 tests, was 172, +1 new)
- [x] New `testPollingSurvivesThrowableFromFetch` arms an `Error` to escape the second `httpGet` call, then asserts the polling task continues to fire (`callCount >= 3` after 2.5s with a 1s interval). Before the fix the scheduler would have cancelled the task on the `Error` and `callCount` would have stopped at 2.
